### PR TITLE
Fix giz logo height

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -576,12 +576,13 @@ header a:focus{
     }
 }
 
+
 #footer-logos-div img{
     height: 7rem;
 }
 
 #footer-logos-giz img{
-    height: 3rem;
+    height: 5.3rem;
 }
 
 #footer-license-div{


### PR DESCRIPTION
Closes #45 

The ratio between the cooperation logo and the giz logo should be approx of 1032 / 780