### PR TITLE
Fix docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM python:3.6.10-alpine3.10
 MAINTAINER Pierre-Francois Duc <pierre-francois.duc@rl-institut.de>
 
 ARG branch=dev
-ARG POSTGRES_URL
-ARG POSTGRES_USER
-ARG POSTGRES_PW
-ARG POSTGRES_DB
+ARG POSTGRES_url
+ARG POSTGRES_user
+ARG POSTGRES_pw
+ARG POSTGRES_db
 
-ENV POSTGRES_URL=$POSTGRES_URL
-ENV POSTGRES_USER=$POSTGRES_USER
-ENV POSTGRES_PW=$POSTGRES_PW
-ENV POSTGRES_DB=$POSTGRES_DB
+ENV POSTGRES_URL=$POSTGRES_url
+ENV POSTGRES_USER=$POSTGRES_user
+ENV POSTGRES_PW=$POSTGRES_pw
+ENV POSTGRES_DB=$POSTGRES_db
 
 COPY docker_postgres_login_help.py /
 COPY app /app
@@ -42,4 +42,3 @@ RUN python /docker_postgres_login_help.py
 
 # Start gunicorn
 CMD ["gunicorn", "index:app"]
-

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ If needed, you can generate a key with `python -c 'import os; print(os.urandom(1
 1. install [docker](https://docs.docker.com/v17.09/engine/installation/linux/docker-ce/ubuntu/#install-docker-ce-1) and [docker-compose](https://docs.docker.com/compose/install/)
 
 ### With simple Dockerfile
-1. `sudo docker build -t nesp2_website .`
-2. `sudo docker run -rm -p 5000:5000 nesp2_website` you can use the `--build-arg` command to provide the postgresql login infos
+1. `sudo docker build -t nesp2_website .` you can use the `--build-arg` command to provide the postgresql login infos, or store 
+   it in a file and run `sudo docker build -t nesp2_website $(<docker-inputs.txt) .`
+2. `sudo docker run -rm -p 5000:5000 nesp2_website`
 3. Access the website at localhost:5000
 4. to stop the service simply `ctrl + c` in the terminal from point 2.
 ### With docker-compose
+0. Define the database env variable either in your terminal or in `.env` file (docker-compose will look into it)
 1. `sudo docker-compose up -d --build`
 2. your app is available at `0.0.0.0:5000` or `localhost:5000`
 3. Access the website at localhost:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ services:
   nesp2_website:
     restart: unless-stopped
     build:
+      args:
+        POSTGRES_url: ${POSTGRES_URL}
+        POSTGRES_user: ${POSTGRES_USER}
+        POSTGRES_pw: ${POSTGRES_PW}
+        POSTGRES_db: ${POSTGRES_DB}
       context: .
     image: nesp2_website
     container_name: nesp2_website


### PR DESCRIPTION
Now the environment variables are correctly provided to the container. They need to exist in the terminal or be defined in an `.env` file