### PR TITLE
Make address from footer in index and about pages look the same

### DIFF
--- a/app/static/about.css
+++ b/app/static/about.css
@@ -1,4 +1,3 @@
 p {
     text-align: justify;
-    padding-right: 10rem;
 }


### PR DESCRIPTION
I only removed a padding that was squeezing the text in about page. I couldn't see any other difference between the two footers #127 