### PR TITLE
reduce card font-size

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -793,6 +793,12 @@ h4.heading-green {
     height: 18rem;
 }
 
+@media only screen and (min-width: 1024px) and (max-width: 1300px) {
+    .landing-resources-grid-y .card .grid-y {
+        height: 23rem;
+    }
+}
+
 .objectives__cards > div {
     display: flex;
     justify-content: space-evenly;
@@ -868,6 +874,12 @@ h4.heading-green {
 .landing-resources-grid-y .card-text {
     background-color: #fff;
     padding: .5rem 1rem;
+}
+
+@media only screen and (min-width: 1024px) {
+    .landing-resources-grid-y .card-text {
+        padding: .5rem .5rem;
+    }
 }
 
 .landing-resources-grid-y .card-text-header {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -843,7 +843,7 @@ h4.heading-green {
 
 @media only screen and (min-width: 1040px) {
     .landing-resources-grid-y .card-text p {
-        font-size: 18pt;
+        font-size: 16pt;
     }
 }
 
@@ -891,6 +891,7 @@ h4.heading-green {
     animation: fade 1s linear;
     opacity: 0;
     animation-fill-mode: forwards;
+    font-size: 16pt;
 }
 .selected--objective-card__content li:nth-of-type(2) {
     animation-delay: .5s;


### PR DESCRIPTION
This is a quick fix for the cards on the landing page. The text was too large and couldn't be contained inside the cards. I probably increased the font-size for the cards on the objectives page, which in turn influenced the cards on the landing page. So I decided to set the font-size to 16pt for the cards on both pages in order to fix the issue and to keep consistent font-sizes throughout the website.