### PR TITLE
Add a warning popup on unsupported browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Here is a template for new release sections
 ```
 ## [Unreleased]
 ### Added
-
+- Popup to warn against unsupported browsers (#183)
 ### Changed
 
 ### Removed

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -78,6 +78,13 @@ def create_app(test_config=None):
             )
             print("\n***************\n\n")
 
+        user_agent = request.headers.get('User-Agent')
+        not_supported = False
+        for ua in maps.UNSUPPORTED_USER_AGENT_STRINGS:
+            if ua in user_agent:
+                not_supported = True
+        kwargs['not_supported'] = not_supported
+        print(kwargs)
         return render_template('landing/index.html', **kwargs)
 
     @app.route('/termsofservice')

--- a/app/blueprints/maps.py
+++ b/app/blueprints/maps.py
@@ -15,15 +15,28 @@ if os.environ.get("POSTGRES_URL", None) is not None:
     STATE_CODES_DICT = get_state_codes()
     CODES_STATE_DICT = {v: k for k, v in STATE_CODES_DICT.items()}
 
+UNSUPPORTED_USER_AGENT_STRINGS = (
+    "Edge",
+    "MSIE",  # Internet Explorer
+    "Trident"  # Internet Explorer (newer versions)
+)
+
 bp = Blueprint('maps', __name__)
 
 
 @bp.route('/maps/')
 @bp.route('/maps')
 def index():
+    user_agent = request.headers.get('User-Agent')
+    not_supported = False
+    for ua in UNSUPPORTED_USER_AGENT_STRINGS:
+        if ua in user_agent:
+            not_supported = True
+
     defaultArgs = {
         "states_content": 1,
-        "grid_content": 1
+        "grid_content": 1,
+        "not_supported": not_supported
     }
     if request.args == {}:
         request.args = defaultArgs

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -49,6 +49,18 @@
   {% for message in get_flashed_messages() %}
     <div class="flash">{{ message }}</div>
   {% endfor %}
+
+  <div class="reveal level" id="warning-browser-not-supported" data-reveal>
+    <h2>Warning</h2>
+    <p>This webmap is not optimized for browsers other than Chrome, Firefox and Opera.</p>
+    <p>For the full functionality please visit from one of these browsers.</p>
+    <div class="sidebar__btn">
+      <button data-close aria-label="Close modal" type="button">
+        Understood
+      </button>
+    </div>
+  </div>
+
   {% block content %}{% endblock %}
 
 

--- a/app/templates/landing/index.html
+++ b/app/templates/landing/index.html
@@ -193,4 +193,18 @@
 
 </div>
 <script src="{{ url_for('static', filename='js/features.js') }}"></script>
+<script type=text/javascript>
+  $(document).ready(function(){
+        //display a warning for not supported browser (the list is in __init__.py in the variable
+        // UNSUPPORTED_USER_AGENT_STRINGS)
+        {% if not_supported == True %}
+            var not_supported = true;
+        {% else %}
+            var not_supported=false;
+        {% endif %}
+        if (not_supported == true){
+            $('#warning-browser-not-supported').foundation('toggle');
+        }
+  });
+</script>
 {% endblock content%}


### PR DESCRIPTION
In `__init__.py`, the user agent of the request is evaluated and if the browser is in the list of unsupported browsers, a popup warning will appear to the user 